### PR TITLE
Ensure Docker image tag uses lowercase repository name

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -22,10 +22,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Prepare repository name
+        id: prep
+        run: echo "repo=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
           push: ${{ github.event_name == 'push' }}
-          tags: ghcr.io/${{ github.repository }}:latest
+          tags: ghcr.io/${{ steps.prep.outputs.repo }}:latest
 


### PR DESCRIPTION
## Summary
- Build workflow lowers `GITHUB_REPOSITORY` before tagging to satisfy GHCR naming rules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eed187af4832a88c424f0afe49624